### PR TITLE
BugFix - Disallow note subject modification in update API

### DIFF
--- a/src/api/route/note.js
+++ b/src/api/route/note.js
@@ -19,9 +19,16 @@ module.exports.get = (req, res) => {
 };
 
 module.exports.update = (req, res) => {
-    return req.note.update(req.body).then(() => {
-        res.json(req.note.expose());
-    });
+
+    if(req.body.hasOwnProperty('subject')) {
+        return Promise.resolve('Forbidden').then(() => {
+            res.sendStatus(403);
+        });
+    } else {
+        return req.note.update(req.body).then(() => {
+            res.json(req.note.expose());
+        });
+    }
 };
 
 module.exports.delete = (req, res) => {

--- a/test/api/route/note.test.js
+++ b/test/api/route/note.test.js
@@ -87,6 +87,19 @@ describe('Tests for api route note', function() {
                 res.json.calledWithExactly('exposedNote').should.be.true();
             });
         });
+
+        it('should not update a note subject then send 403 Forbidden status', () => {
+            req.note = note;
+
+            req.body = {
+                subject: 'updated subject'
+            };
+
+            return route.note.update(req, res).then(() => {
+                req.note.update.calledWithExactly(req.body).should.be.false();
+                res.sendStatus.calledWithExactly(403).should.be.true();
+            });
+        });
     });
 
     describe('delete', () => {


### PR DESCRIPTION
## Bug
Calling the note update API with subject parameter in the request updates the note subject.

## How to reproduce
Note update api causing the bug: `http://localhost:7428/api/notes/:id`
**Tools used** - Chrome browser, Postman

- Login to account, username -> user1, password -> password1
- Create a dummy note, update the dummy note.
- Intercept the API's calls while updating the note using postman intercepter
- The API's used for updating the note are updated in Postman with cookie data i.e sessionId
- Now add `subject` key with some value in the request body parameters of update API using Postman and send the request.
- Check the note data, it's subject is updated.

## Other problems this bug might cause
Not checking parameters before passing it to might change important information which is used for identifying or relating that model with other models.
This will lead to bad records in DB.

## How to Fix
### Way 1 - Add a check in the api call. There are two ways to add checks in api.
#### a. Add checks for disallowed fields in request body. 
For example if only note body can be updated -
- If request contains disallowed fields like note subject, respond with 403 Forbidden.
  i.e Server knows what you are sending but it disallows editing that field.
- If request contains any other field other than body respond with 400 BadRequest.

#### b. Modify the request body
Copy request parameters that are allowed to be modified and pass it to the update method by ignoring any other extra fields passed in the request body.

### Way 2 - Disallow update in model
If we are pretty sure a model attribute should not be allowed to update at all, add a check in model. 
For example there is a plugin in `Sequelize`  to add checks in model https://www.npmjs.com/package/sequelize-noupdate-attributes. 

Sometimes need arises that business logic does not want the user to update a model attribute instead application itself needs to update the field according to some conditions. Hence Way 1 is better than Way 2.