### PR TITLE
[Feature] Add Note versioning - WIP

### DIFF
--- a/public/src/common/dropdown.html
+++ b/public/src/common/dropdown.html
@@ -1,0 +1,14 @@
+<!-- 
+<div>
+    <button class="btn btn-default" dropdown-toggle type="button" id="dropdownMenu1" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+        Subject
+        <span class="caret"></span>
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="dropdownMenu1">
+        <li ng-repeat="versionId in $ctrl.versionIds">
+          <a ng-bind="versionId"></a>
+        </li>
+    </ul>
+</div>
+
+ -->

--- a/public/src/common/dropdown.js
+++ b/public/src/common/dropdown.js
@@ -1,0 +1,19 @@
+'use strict';
+
+angular.module('app').component('dropdown', {
+    templateUrl: '/src/common/dropdown.html',
+    bindings: {
+        versions: '<',
+    },
+    controller: function() {
+        this.$onInit = function() {
+            if (!_.isEmpty(this.versions)) {
+                this.versionIds = this.versions.map(version => version.versionId);
+            }
+        };
+
+        // this.onToggle = function() {
+        //     // ToDo
+        // };
+    },
+});

--- a/public/src/note/detail.html
+++ b/public/src/note/detail.html
@@ -6,6 +6,7 @@
 </ol>
 
 <p class="clearfix">
+    <dropdown versions="$ctrl.versions"></dropdown>
     <a class="btn btn-default pull-right" ng-href="#!/notes/{{ $ctrl.note.id }}/edit">Edit</a>
 </p>
 

--- a/public/src/note/detail.js
+++ b/public/src/note/detail.js
@@ -5,5 +5,6 @@ angular.module('app').component('noteDetail', {
     bindings: {
         session: '<',
         note: '<',
+        versions: '<',
     },
 });

--- a/public/src/resources/version.js
+++ b/public/src/resources/version.js
@@ -1,0 +1,10 @@
+'use strict';
+
+angular.module('app').factory('Version', function($resource) {
+    return $resource('/api/notes/:noteId/versions', {}, {
+        query: {
+            method: 'GET',
+            isArray: true
+        },
+    });
+});

--- a/public/src/routes.js
+++ b/public/src/routes.js
@@ -31,11 +31,14 @@ angular.module('app').config(function($routeProvider) {
     };
 
     const noteDetailPage = {
-        template: '<note-detail session="$resolve.session" note="$resolve.note"></note-detail>',
+        template: '<note-detail session="$resolve.session" note="$resolve.note" versions="$resolve.versions"></note-detail>',
         resolve: {
             session: Session => Session.current().$promise,
             note: (Note, $route) => Note.get({
                 id: $route.current.params.noteId
+            }).$promise,
+            versions: (Version, $route) => Version.query({
+                noteId: $route.current.params.noteId
             }).$promise
         }
     };

--- a/src/api/route/note.js
+++ b/src/api/route/note.js
@@ -18,6 +18,12 @@ module.exports.get = (req, res) => {
     res.json(req.note.expose());
 };
 
+module.exports.versions = (req, res) => {
+    return req.note.versions().then(versions => {
+        res.json(_.invokeMap(versions, 'expose'));
+    });
+};
+
 module.exports.update = (req, res) => {
     return req.note.update(req.body).then(() => {
         res.json(req.note.expose());

--- a/src/api/router/index.js
+++ b/src/api/router/index.js
@@ -41,6 +41,10 @@ function setupRoutesWithRequiredAuthentication(router) {
         '/notes/:noteId',
         route.note.get
     );
+    router.get(
+        '/notes/:noteId/versions',
+        route.note.versions
+    );
     router.put(
         '/notes/:noteId',
         apiMiddleware.jsonParser,

--- a/src/domain/error.js
+++ b/src/domain/error.js
@@ -21,6 +21,7 @@ DomainError.Code = _.extend(_.transform([
 }), _.transform([
     'USER_NOT_FOUND',
     'NOTE_NOT_FOUND',
+    'VERSION_NOT_FOUND',
 ], (result, code) => {
     result[code] = {
         name: code,

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const _ = require('lodash');
+const model = require('../model');
 
 class Note {
     constructor(note) {
@@ -21,7 +22,33 @@ class Note {
     }
 
     update(note) {
-        return this._note.update(note);
+        const self = this;
+        const initialVersionId = 1;
+
+        return model.sequelize.transaction(function (t) {
+            // chain all your queries here.
+            return self._note.getVersions({
+                order: [['createdAt', 'DESC']],
+            }, {transaction: t}).then(versions => {
+
+                const lastVersionId = versions.length > 0 ? versions[0].versionId + 1 : initialVersionId;
+                const version = {
+                    subject: self._note.subject,
+                    body: self._note.body,
+                    versionId: lastVersionId
+                }
+
+                return self._note.update(note, {transaction: t}).then( updatedNote => {
+                   return self._note.createVersion(version, {transaction: t}).then( function() {
+                        return updatedNote
+                   });
+                });
+            });
+        }).then(function (result) {
+            return result;
+        }).catch(function (err) {
+            throw new Error(err);
+        });
     }
 
     delete() {

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -27,6 +27,31 @@ class Note {
     delete() {
         return this._note.destroy();
     }
+
+    versions() {
+        return this._note.getVersions({
+            order: [['createdAt', 'DESC']],
+        }).then(versions => {
+            return _.map(versions, version => {
+                return new domain.Version(version);
+            });
+        });
+    }
+
+    version(id) {
+        return this._note.getVersions({
+            where: {
+                id
+            },
+        }).then(versions => {
+            if (_.size(versions) !== 1) {
+                return q.reject(new domain.Error(domain.Error.Code.VERSION_NOT_FOUND));
+            }
+            else {
+                return new domain.Version(versions[0]);
+            }
+        });
+    }
 }
 
 module.exports = Note;

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const model = require('../model');
+const domain = require('../domain');
 
 class Note {
     constructor(note) {

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -23,22 +23,16 @@ class Note {
 
     update(note) {
         const self = this;
-        const initialVersionId = 1;
-
         return model.sequelize.transaction(function (t) {
-            // chain all your queries here.
             return self._note.getVersions({
                 order: [['createdAt', 'DESC']],
             }, {transaction: t}).then(versions => {
-
-                const lastVersionId = versions.length > 0 ? versions[0].versionId + 1 : initialVersionId;
                 const version = {
                     subject: self._note.subject,
-                    body: self._note.body,
-                    versionId: lastVersionId
+                    body: note.body,
+                    versionId: versions[0].versionId + 1
                 }
-
-                return self._note.update(note, {transaction: t}).then( updatedNote => {
+                return self._note.update(note, {transaction: t}).then(updatedNote => {
                    return self._note.createVersion(version, {transaction: t}).then( function() {
                         return updatedNote
                    });

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -4,6 +4,7 @@ const _ = require('lodash');
 const model = require('../model');
 const domain = require('../domain');
 const q = require('q');
+
 class Note {
     constructor(note) {
         this._note = note;
@@ -34,9 +35,9 @@ class Note {
                     versionId: versions[0].versionId + 1
                 };
                 return self._note.update(note, {transaction: t}).then(updatedNote => {
-                   return self._note.createVersion(version, {transaction: t}).then( function() {
+                    return self._note.createVersion(version, {transaction: t}).then(function () {
                         return updatedNote;
-                   });
+                    });
                 });
             });
         }).then(function (result) {

--- a/src/domain/note.js
+++ b/src/domain/note.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const model = require('../model');
 const domain = require('../domain');
-
+const q = require('q');
 class Note {
     constructor(note) {
         this._note = note;
@@ -32,10 +32,10 @@ class Note {
                     subject: self._note.subject,
                     body: note.body,
                     versionId: versions[0].versionId + 1
-                }
+                };
                 return self._note.update(note, {transaction: t}).then(updatedNote => {
                    return self._note.createVersion(version, {transaction: t}).then( function() {
-                        return updatedNote
+                        return updatedNote;
                    });
                 });
             });

--- a/src/domain/user.js
+++ b/src/domain/user.js
@@ -58,12 +58,6 @@ class User {
     }
 
     createNote(note) {
-        return this._user.createNote(note).then(modelNote => {
-            return new domain.Note(modelNote);
-        });
-    }
-
-    createNote(note) {
         const version = {
             subject: note.subject,
             body: note.body,

--- a/src/domain/user.js
+++ b/src/domain/user.js
@@ -63,6 +63,26 @@ class User {
         });
     }
 
+    createNote(note) {
+        const version = {
+            subject: note.subject,
+            body: note.body,
+            versionId: 1
+        };
+        const self = this;
+        return model.sequelize.transaction(function (t) {
+            return self._user.createNote(note, {transaction: t}).then(modelNote => {
+               return modelNote.createVersion(version, {transaction: t}).then( function() {
+                    return new domain.Note(modelNote);
+               });
+            });
+        }).then(function (result) {
+            return result;
+        }).catch(function (err) {
+            throw new Error(err);
+        });
+    }
+
     static getById(id) {
         return model.User.findOne({
             where: {

--- a/src/domain/user.js
+++ b/src/domain/user.js
@@ -66,9 +66,9 @@ class User {
         const self = this;
         return model.sequelize.transaction(function (t) {
             return self._user.createNote(note, {transaction: t}).then(modelNote => {
-               return modelNote.createVersion(version, {transaction: t}).then( function() {
+                return modelNote.createVersion(version, {transaction: t}).then( function() {
                     return new domain.Note(modelNote);
-               });
+                });
             });
         }).then(function (result) {
             return result;

--- a/src/domain/version.js
+++ b/src/domain/version.js
@@ -12,12 +12,13 @@ class Version {
     }
 
     expose() {
-        return _.pick(this._note, [
+        return _.pick(this._version, [
             'id',
             'subject',
             'body',
             'versionId',
-            'createdAt'
+            'createdAt',
+            'noteId'
         ]);
     }
 }

--- a/src/domain/version.js
+++ b/src/domain/version.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const _ = require('lodash');
+
+class Version {
+    constructor(version) {
+        this._version = version;
+    }
+
+    get id() {
+        return this._version.id;
+    }
+
+    expose() {
+        return _.pick(this._note, [
+            'id',
+            'subject',
+            'body',
+            'versionId',
+            'createdAt'
+        ]);
+    }
+}
+
+module.exports = Version;

--- a/src/model/index.js
+++ b/src/model/index.js
@@ -9,13 +9,17 @@ const sequelize = new Sequelize(config.postgresql.url, {
 const User = require('./user');
 const Note = require('./note');
 const userNoteAssociation = require('./userNote');
+const Version = require('./version');
+const noteVersionAssociation = require('./noteVersion');
 
 const models = {
     sequelize,
     User: User.define(sequelize),
     Note: Note.define(sequelize),
+    Version: Version.define(sequelize),
 };
 
 userNoteAssociation.define(models);
+noteVersionAssociation.define(models);
 
 module.exports = models;

--- a/src/model/noteVersion.js
+++ b/src/model/noteVersion.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports.define = models => {
+    models.Note.hasMany(models.Version, {
+        foreignKey: {
+            name: 'noteId',
+            allowNull: false
+        },
+        as: 'versions',
+        onUpdate: 'RESTRICT',
+        onDelete: 'CASCADE'
+    });
+};

--- a/src/model/version.js
+++ b/src/model/version.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const Sequelize = require('sequelize');
+
+module.exports.define = sequelize => {
+    return sequelize.define('Version', {
+        id: {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            primaryKey: true,
+            autoIncrement: true
+        },
+        subject: {
+            type: Sequelize.STRING,
+            allowNull: false,
+            validate: {
+                notEmpty: true
+            }
+        },
+        body: {
+            type: Sequelize.TEXT,
+            allowNull: false,
+            validate: {
+                notEmpty: true
+            }
+        },
+        versionId: {
+            type: Sequelize.INTEGER,
+            allowNull: false,
+            validate: {
+                notEmpty: true
+            }  
+        },
+    }, {
+        indexes: [
+            {
+                name: 'Notes_version_id',
+                unique: true,
+                fields: ['noteId', 'versionId']
+            },
+        ],
+    });
+};


### PR DESCRIPTION
## Feature description 
For user to check the steps taken to reach the current status of note maintain a history of edits done by user for that particular note.
Version number should start from 1 to n, n being the latest version.

## Implementation details 
### Back-end 
- Create a `Versions` table with `noteId` as foreign Id, add constraint 
(versionId, noteId) should be unique so that for each note edit new version is created 
- Latest version is always stored in `Notes` table 
- Add logic in Note `create` and update` method to add record details in `Versions` table
- If any error happens in either of the query, all of the query should be rolled back. Rollback should be done using *sequelize transaction*.
- Once above is done add methods to create update or delete for Note Version in `domain/note.js`.
- Above methods should be called while talking to front-end.

### Front-end 
- Add `Version` in resource to get Version details from back-end.
   - URL's which make sense to get a note with particular version should be meaningful which tells the user about where he/she is for ex. `/api/notes/:noteId/versions/:versionId`
- Component to display different versions for note should be something easy to access, selectable and which takes less space on page, for above properties a `Dropdown` component seems like a best choice. Also for selecting different versions, by default many sites use dropdown, for ex. Github uses dropdown for selecting a branch. Though some other component might be better which I am not aware of.
   - Bootstrap's dropdown class in Angular doesn't seem compatible, need to install ui-bootstrap to get dropdown working in current environment.
 
### Tests 
- ToDo
